### PR TITLE
scala 2.13 build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: scala
 scala:
   - 2.13.0
-  - 2.12.7
-  - 2.11.11
+  - 2.12.10
+  - 2.11.12
 jdk:
   - openjdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ scala:
   - 2.12.7
   - 2.11.11
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 script: |
   sbt ++$TRAVIS_SCALA_VERSION clean coverage test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: scala
 scala:
+  - 2.13.0
   - 2.12.7
   - 2.11.11
 jdk:

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ publishTo := Some(
   else
     "releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
 startYear := Some(2016)
-organizationHomepage := Some(url("https://github.com/sangria-graphql"))
+organizationHomepage := Some(url("https://github.com/sangria-graphql-org"))
 developers := Developer("OlegIlyenko", "Oleg Ilyenko", "", url("https://github.com/OlegIlyenko")) :: Nil
 scmInfo := Some(ScmInfo(
   browseUrl = url("https://github.com/sangria-graphql-org/sangria-play-json.git"),

--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,8 @@ libraryDependencies ++= Seq(
   "org.sangria-graphql" %% "sangria-marshalling-api" % "1.0.4",
   "com.typesafe.play" %% "play-json" % "2.7.4",
 
-  "org.sangria-graphql" %% "sangria-marshalling-testkit" % "1.0.2" % "test",
-  "org.scalatest" %% "scalatest" % "3.0.8" % "test")
+  "org.sangria-graphql" %% "sangria-marshalling-testkit" % "1.0.2" % Test,
+  "org.scalatest" %% "scalatest" % "3.0.8" % Test)
 
 // Publishing
 
@@ -34,8 +34,8 @@ startYear := Some(2016)
 organizationHomepage := Some(url("https://github.com/sangria-graphql"))
 developers := Developer("OlegIlyenko", "Oleg Ilyenko", "", url("https://github.com/OlegIlyenko")) :: Nil
 scmInfo := Some(ScmInfo(
-  browseUrl = url("https://github.com/sangria-graphql/sangria-play-json.git"),
-  connection = "scm:git:git@github.com:sangria-graphql/sangria-play-json.git"))
+  browseUrl = url("https://github.com/sangria-graphql-org/sangria-play-json.git"),
+  connection = "scm:git:git@github.com:sangria-graphql-org/sangria-play-json.git"))
 
 // nice *magenta* prompt!
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 name := "sangria-play-json"
 organization := "org.sangria-graphql"
 version := "1.0.6-SNAPSHOT"
+mimaPreviousArtifacts := Set("org.sangria-graphql" %% "sangria-play-json" % "1.0.5")
 
 description := "Sangria play-json marshalling"
 homepage := Some(url("http://sangria-graphql.org"))
@@ -20,6 +21,8 @@ libraryDependencies ++= Seq(
 
 // Publishing
 
+releaseCrossBuild := true
+releasePublishArtifactsAction := PgpKeys.publishSigned.value
 publishMavenStyle := true
 publishArtifact in Test := false
 pomIncludeRepository := (_ ⇒ false)

--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ description := "Sangria play-json marshalling"
 homepage := Some(url("http://sangria-graphql.org"))
 licenses := Seq("Apache License, ASL Version 2.0" → url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-scalaVersion := "2.12.7"
-crossScalaVersions := Seq("2.11.11", "2.12.7", "2.13.0")
+scalaVersion := "2.13.0"
+crossScalaVersions := Seq("2.11.12", "2.12.10", scalaVersion.value)
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 name := "sangria-play-json"
 organization := "org.sangria-graphql"
-version := "1.0.6-SNAPSHOT"
 mimaPreviousArtifacts := Set("org.sangria-graphql" %% "sangria-play-json" % "1.0.5")
 
 description := "Sangria play-json marshalling"

--- a/build.sbt
+++ b/build.sbt
@@ -7,16 +7,16 @@ homepage := Some(url("http://sangria-graphql.org"))
 licenses := Seq("Apache License, ASL Version 2.0" → url("http://www.apache.org/licenses/LICENSE-2.0"))
 
 scalaVersion := "2.12.7"
-crossScalaVersions := Seq("2.11.11", "2.12.7")
+crossScalaVersions := Seq("2.11.11", "2.12.7", "2.13.1")
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 
 libraryDependencies ++= Seq(
-  "org.sangria-graphql" %% "sangria-marshalling-api" % "1.0.3",
-  "com.typesafe.play" %% "play-json" % "2.6.10",
+  "org.sangria-graphql" %% "sangria-marshalling-api" % "1.0.4",
+  "com.typesafe.play" %% "play-json" % "2.7.4",
 
-  "org.sangria-graphql" %% "sangria-marshalling-testkit" % "1.0.1" % "test",
-  "org.scalatest" %% "scalatest" % "3.0.5" % "test")
+  "org.sangria-graphql" %% "sangria-marshalling-testkit" % "1.0.2" % "test",
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test")
 
 // Publishing
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ homepage := Some(url("http://sangria-graphql.org"))
 licenses := Seq("Apache License, ASL Version 2.0" → url("http://www.apache.org/licenses/LICENSE-2.0"))
 
 scalaVersion := "2.12.7"
-crossScalaVersions := Seq("2.11.11", "2.12.7", "2.13.1")
+crossScalaVersions := Seq("2.11.11", "2.12.7", "2.13.0")
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.2.8

--- a/project/coverage.sbt
+++ b/project/coverage.sbt
@@ -1,2 +1,0 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")

--- a/project/coverage.sbt
+++ b/project/coverage.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,10 @@
+resolvers += Resolver.url(
+  "typesafe sbt-plugins",
+  url("https://dl.bintray.com/typesafe/sbt-plugins")
+)(Resolver.ivyStylePatterns)
+
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")

--- a/src/main/scala/sangria/marshalling/playJson.scala
+++ b/src/main/scala/sangria/marshalling/playJson.scala
@@ -51,7 +51,7 @@ object playJson extends PlayJsonSupportLowPrioImplicits {
     def getRootMapValue(node: JsValue, key: String) = node.asInstanceOf[JsObject].value get key
 
     def isListNode(node: JsValue) = node.isInstanceOf[JsArray]
-    def getListValue(node: JsValue) = node.asInstanceOf[JsArray].value
+    def getListValue(node: JsValue) = node.asInstanceOf[JsArray].value.toSeq
 
     def isMapNode(node: JsValue) = node.isInstanceOf[JsObject]
     def getMapValue(node: JsValue, key: String) = node.asInstanceOf[JsObject].value get key

--- a/src/main/scala/sangria/marshalling/playJson.scala
+++ b/src/main/scala/sangria/marshalling/playJson.scala
@@ -51,7 +51,7 @@ object playJson extends PlayJsonSupportLowPrioImplicits {
     def getRootMapValue(node: JsValue, key: String) = node.asInstanceOf[JsObject].value get key
 
     def isListNode(node: JsValue) = node.isInstanceOf[JsArray]
-    def getListValue(node: JsValue) = node.asInstanceOf[JsArray].value.toSeq
+    def getListValue(node: JsValue) = node.asInstanceOf[JsArray].value.toIndexedSeq
 
     def isMapNode(node: JsValue) = node.isInstanceOf[JsObject]
     def getMapValue(node: JsValue, key: String) = node.asInstanceOf[JsObject].value get key

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "2.0.0-SNAPSHOT"


### PR DESCRIPTION
* needed to update play-json as there is no play-json 2.6 jar that supports scala 2.13
* the mima check fails

`[error]  * method getListValue(play.api.libs.json.JsValue)scala.collection.IndexedSeq in object sangria.marshalling.playJson#PlayJsonInputUnmarshaller has a different result type in current version, where it is scala.collection.immutable.IndexedSeq rather than scala.collection.IndexedSeq
[error]    filter with: ProblemFilters.exclude[IncompatibleResultTypeProblem]("sangria.marshalling.playJson#PlayJsonInputUnmarshaller.getListValue")`

* I tried to make the return types explicit (in https://github.com/sangria-graphql-org/sangria-play-json/blob/master/src/main/scala/sangria/marshalling/playJson.scala#L50) - to match InputUnmarshaller but that led to even more mima errors

