### PR TITLE
Updated play to 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: scala
 scala:
   - 2.13.0
   - 2.12.10
-  - 2.11.12
 jdk:
   - openjdk8
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,13 +7,13 @@ homepage := Some(url("http://sangria-graphql.org"))
 licenses := Seq("Apache License, ASL Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 
 scalaVersion := "2.13.0"
-crossScalaVersions := Seq("2.11.12", "2.12.10", scalaVersion.value)
+crossScalaVersions := Seq("2.12.10", scalaVersion.value)
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 
 libraryDependencies ++= Seq(
   "org.sangria-graphql" %% "sangria-marshalling-api" % "1.0.4",
-  "com.typesafe.play" %% "play-json" % "2.7.4",
+  "com.typesafe.play" %% "play-json" % "2.8.1",
 
   "org.sangria-graphql" %% "sangria-marshalling-testkit" % "1.0.2" % Test,
   "org.scalatest" %% "scalatest" % "3.0.8" % Test)


### PR DESCRIPTION
Play 2.8 is available and it dropped support for Scala 2.11.